### PR TITLE
chore: Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    reviewers:
-      - "juissi-t"
     commit-message:
       prefix: fix(deps)
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "monthly"
-    reviewers:
-      - "juissi-t"
     commit-message:
       prefix: fix(deps)


### PR DESCRIPTION
Remove deprecated reviewers section from dependabot config